### PR TITLE
Fix: Convert boolean outputs to strings for GitHub Actions compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Minecraft Server Automation with CI/CD
 
-<!-- Test: Verify label-based environment targeting works with string outputs -->
+<!-- Test: To verify label-based environment targeting, deploy the infrastructure using Terragrunt with the appropriate environment label (e.g., 'keeping' or 'scheduling'). Confirm that resources are provisioned according to the label, and that outputs (such as resource ARNs or endpoints) are returned as strings matching the expected environment. For example, running 'terragrunt apply --env scheduling' should create only the cost-optimized resources and output their identifiers as strings. -->
 
 Cost-optimized Minecraft server infrastructure using **Terragrunt** for multi-environment management and automated CI/CD.
 


### PR DESCRIPTION
- environment-target-checker.js: Return string values instead of boolean
- Add test comment to README for verification
- Ensures GitHub Actions IF conditions work correctly with 'true'/'false' strings