### PR TITLE
Add manual PR approval via /approve command

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -39,8 +39,9 @@ jobs:
     steps:
       - name: Check comment format
         id: check-command
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          COMMENT_BODY="${{ github.event.comment.body }}"
           echo "Original comment: $COMMENT_BODY"
           
           # Check if comment starts with /approve (allowing for whitespace)


### PR DESCRIPTION
## 🎯 概要
Repository ownerが  コマンドをコメントすることで、GitHub Actions botが自動的にPRをapproveする機能を追加しました。

## ✨ 主な機能

### 1. **手動Approvalコマンド**
- Repository owner（ShotaroMatsuya）がPRコメントで  と入力
- github-actions[bot]が自動的にPRをapprove
- 既存の自動approval機能は保持

### 2. **コマンド形式**
```
/approve
```
または
```
/approve この変更は問題ありません
```

### 3. **安全機能**
- ✅ **権限チェック**: Repository ownerのみ実行可能
- ✅ **重複防止**: 既にapprove済みの場合は適切に処理
- ✅ **ステータス確認**: openなPRのみ対象
- ✅ **コマンド検証**: がコメントの先頭にある場合のみ有効

### 4. **ユーザーフィードバック**
- 🎯 **リアクション**: コマンドに対して適切なリアクション（👍、👀、😕、❌）
- 💬 **ステータスコメント**: 処理結果をわかりやすくコメント
- 📝 **詳細ログ**: 処理過程をログで確認可能

## 🔄 動作フロー

1. Repository ownerがPRコメントで  を投稿
2. GitHub Actionsが  イベントをキャッチ
3. コマンド形式と権限を検証
4. PRの状態をチェック（open、既にapprove済みかなど）
5. github-actions[bot]としてPRをapprove
6. コマンドにリアクションを追加
7. 成功/失敗をコメントで通知

## 🧪 テスト方法

1. このPRがマージされた後
2. 新しいPRを作成
3. Repository ownerとして  をコメント
4. github-actions[bot]が自動的にapproveすることを確認

## 📋 使用例

### 成功ケース
```
/approve
```
→ ✅ PR approved + 🎉 リアクション + 成功コメント

### 既にapprove済み
```
/approve
```
→ 👀 リアクション + 「既にapprove済み」コメント

### 無効なフォーマット
```
この変更を /approve します
```
→ ❌ リアクション + フォーマット説明コメント

## 🔒 セキュリティ

- Repository ownerのみがコマンドを実行可能
- openなPRでのみ動作
- 適切な権限設定（pull-requests: write, issues: write）

この機能により、Repository ownerは素早く効率的にPRをapproveできるようになります。