### PR TITLE
test: Verify apply-scheduling fix when apply-keeping is skipped

### DIFF
--- a/test-scheduling-fix.md
+++ b/test-scheduling-fix.md
@@ -1,0 +1,23 @@
+# Test Apply-Scheduling Fix
+
+This is a test file to verify that the apply-scheduling job condition fix works correctly.
+
+## Expected Behavior
+
+When this PR is labeled with `target:scheduling`:
+
+- apply-keeping should be skipped (should_run_keeping=false)
+- apply-scheduling should run (should_run_scheduling=true)
+- apply-scheduling job should execute successfully
+
+## Test Date
+
+2025-08-11
+
+## Changes Made
+
+- Fixed apply-scheduling job condition to handle when apply-keeping is skipped
+- Added explicit check for `should_run_keeping == 'false'`
+- Enhanced debug logging
+
+This file can be deleted after testing is complete.


### PR DESCRIPTION
## 🧪 Test Purpose

This PR tests the fix for apply-scheduling job condition that was preventing it from running when apply-keeping is skipped.

## �� Expected Results

After adding `target:scheduling` label to this PR and merging:

1. **check-changes job**: 
   - should_run_keeping = false
   - should_run_scheduling = true

2. **apply-keeping job**: 
   - Should be SKIPPED (due to should_run_keeping=false)

3. **apply-scheduling job**: 
   - Should RUN (due to new condition: should_run_keeping == 'false')
   - Debug output should show detailed condition evaluation

## 🔧 Fix Details

Updated apply-scheduling condition from:
```yaml
if: |
  needs.check-changes.outputs.should_run_scheduling == 'true' && 
  (needs.apply-keeping.outputs.apply_status == 'success' || needs.apply-keeping.result == 'skipped')
```

To:
```yaml
if: |
  needs.check-changes.outputs.should_run_scheduling == 'true' && 
  (needs.apply-keeping.result == 'success' || needs.apply-keeping.result == 'skipped' || needs.check-changes.outputs.should_run_keeping == 'false')
```

## 📋 Test Instructions

1. Add `target:scheduling` label to this PR
2. Merge the PR
3. Check GitHub Actions logs for apply workflow
4. Verify apply-scheduling job runs successfully
5. Delete test file after verification

## 🧹 Cleanup

The test file `test-scheduling-fix.md` should be deleted after testing is complete.