### PR TITLE
Fix apply-scheduling job execution by restructuring apply-keeping job

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -204,19 +204,30 @@ jobs:
     name: Terragrunt Apply - Keeping
     runs-on: ubuntu-latest
     needs: [check-changes]
-    if: needs.check-changes.outputs.should_run_keeping == 'true'
     outputs:
-      apply_status: ${{ steps.apply.outputs.status }}
-      resources_applied: ${{ steps.apply.outputs.resources_applied }}
-      resources_changed: ${{ steps.apply.outputs.resources_changed }}
-      resources_destroyed: ${{ steps.apply.outputs.resources_destroyed }}
+      apply_status: ${{ steps.determine-status.outputs.status }}
+      resources_applied: ${{ steps.apply.outputs.resources_applied || 0 }}
+      resources_changed: ${{ steps.apply.outputs.resources_changed || 0 }}
+      resources_destroyed: ${{ steps.apply.outputs.resources_destroyed || 0 }}
     steps:
+      - name: Check if job should run
+        id: should-run
+        run: |
+          SHOULD_RUN="${{ needs.check-changes.outputs.should_run_keeping }}"
+          echo "should_run_keeping: $SHOULD_RUN"
+          if [ "$SHOULD_RUN" = "true" ]; then
+            echo "✅ Job should run"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "⏭️ Job should be skipped"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Debug Job Conditions
         run: |
           echo "=== Debugging apply-keeping job conditions ==="
           echo "should_run_keeping output: '${{ needs.check-changes.outputs.should_run_keeping }}'"
-          echo "Type check: '${{ needs.check-changes.outputs.should_run_keeping }}' == 'true'"
-          echo "Condition result: ${{ needs.check-changes.outputs.should_run_keeping == 'true' }}"
+          echo "Job will run: '${{ steps.should-run.outputs.run }}'"
           echo "All check-changes outputs:"
           echo "  changes: '${{ needs.check-changes.outputs.changes }}'"
           echo "  keeping_changes: '${{ needs.check-changes.outputs.keeping_changes }}'"
@@ -283,7 +294,7 @@ jobs:
 
       - name: Terragrunt Apply - Keeping
         id: apply
-        if: steps.check-env.outputs.exists == 'true'
+        if: steps.should-run.outputs.run == 'true' && steps.check-env.outputs.exists == 'true'
         working-directory: terragrunt/environments/keeping
         run: |
           # Function to handle state lock issues
@@ -492,13 +503,33 @@ jobs:
           SLACK_COLOR: danger
           SLACK_MESSAGE: "keeping environment apply failed 😢"
 
+      - name: Determine Final Status
+        id: determine-status
+        if: always()
+        run: |
+          if [ "${{ steps.should-run.outputs.run }}" != "true" ]; then
+            echo "status=skipped" >> "$GITHUB_OUTPUT"
+            echo "Final status: skipped (should not run)"
+          elif [ "${{ steps.check-env.outputs.exists }}" != "true" ]; then
+            echo "status=skipped" >> "$GITHUB_OUTPUT"
+            echo "Final status: skipped (environment does not exist)"
+          elif [ "${{ steps.apply.outputs.status }}" != "" ]; then
+            echo "status=${{ steps.apply.outputs.status }}" >> "$GITHUB_OUTPUT"
+            echo "Final status: ${{ steps.apply.outputs.status }}"
+          else
+            echo "status=unknown" >> "$GITHUB_OUTPUT"
+            echo "Final status: unknown"
+          fi
+
   apply-scheduling:
     name: Terragrunt Apply - Scheduling
     runs-on: ubuntu-latest
     needs: [check-changes, apply-keeping]
     if: |
       needs.check-changes.outputs.should_run_scheduling == 'true' && 
-      (needs.apply-keeping.result == 'success' || needs.apply-keeping.result == 'skipped' || needs.check-changes.outputs.should_run_keeping == 'false')
+      (needs.apply-keeping.outputs.apply_status == 'success' || 
+       needs.apply-keeping.outputs.apply_status == 'skipped' || 
+       needs.check-changes.outputs.should_run_keeping == 'false')
     outputs:
       apply_status: ${{ steps.apply.outputs.status }}
       resources_applied: ${{ steps.apply.outputs.resources_applied }}
@@ -512,12 +543,11 @@ jobs:
           echo "should_run_keeping output: '${{ needs.check-changes.outputs.should_run_keeping }}'"
           echo "Type check: '${{ needs.check-changes.outputs.should_run_scheduling }}' == 'true'"
           echo "Condition result: ${{ needs.check-changes.outputs.should_run_scheduling == 'true' }}"
-          echo "apply-keeping result: '${{ needs.apply-keeping.result }}'"
           echo "apply-keeping apply_status: '${{ needs.apply-keeping.outputs.apply_status }}'"
-          echo "apply-keeping skipped check: ${{ needs.apply-keeping.result == 'skipped' }}"
+          echo "apply-keeping skipped check: ${{ needs.apply-keeping.outputs.apply_status == 'skipped' }}"
           echo "apply-keeping success check: ${{ needs.apply-keeping.outputs.apply_status == 'success' }}"
           echo "should_run_keeping false check: ${{ needs.check-changes.outputs.should_run_keeping == 'false' }}"
-          echo "Updated combined condition: ${{ needs.check-changes.outputs.should_run_scheduling == 'true' && (needs.apply-keeping.result == 'success' || needs.apply-keeping.result == 'skipped' || needs.check-changes.outputs.should_run_keeping == 'false') }}"
+          echo "Updated combined condition: ${{ needs.check-changes.outputs.should_run_scheduling == 'true' && (needs.apply-keeping.outputs.apply_status == 'success' || needs.apply-keeping.outputs.apply_status == 'skipped' || needs.check-changes.outputs.should_run_keeping == 'false') }}"
           echo "All check-changes outputs:"
           echo "  changes: '${{ needs.check-changes.outputs.changes }}'"
           echo "  keeping_changes: '${{ needs.check-changes.outputs.keeping_changes }}'"
@@ -748,7 +778,7 @@ jobs:
     name: Comment Apply Results
     runs-on: ubuntu-latest
     needs: [check-changes, apply-keeping, apply-scheduling]
-    if: always() && needs.check-changes.outputs.pr_number != '' && needs.check-changes.outputs.pr_number != null && (needs.apply-keeping.result == 'success' || needs.apply-scheduling.result == 'success' || needs.apply-keeping.result == 'failure' || needs.apply-scheduling.result == 'failure')
+    if: always() && needs.check-changes.outputs.pr_number != '' && needs.check-changes.outputs.pr_number != null && (needs.apply-keeping.outputs.apply_status == 'success' || needs.apply-scheduling.outputs.apply_status == 'success' || needs.apply-keeping.outputs.apply_status == 'failed' || needs.apply-scheduling.outputs.apply_status == 'failed')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -762,7 +792,7 @@ jobs:
               {
                 name: 'keeping',
                 status: '${{ needs.apply-keeping.outputs.apply_status }}',
-                wasExecuted: '${{ needs.apply-keeping.result }}' !== 'skipped',
+                wasExecuted: '${{ needs.apply-keeping.outputs.apply_status }}' !== 'skipped' && '${{ needs.apply-keeping.outputs.apply_status }}' !== '',
                 resourcesApplied: '${{ needs.apply-keeping.outputs.resources_applied }}' || '0',
                 resourcesChanged: '${{ needs.apply-keeping.outputs.resources_changed }}' || '0',
                 resourcesDestroyed: '${{ needs.apply-keeping.outputs.resources_destroyed }}' || '0'
@@ -770,7 +800,7 @@ jobs:
               {
                 name: 'scheduling', 
                 status: '${{ needs.apply-scheduling.outputs.apply_status }}',
-                wasExecuted: '${{ needs.apply-scheduling.result }}' !== 'skipped',
+                wasExecuted: '${{ needs.apply-scheduling.outputs.apply_status }}' !== 'skipped' && '${{ needs.apply-scheduling.outputs.apply_status }}' !== '',
                 resourcesApplied: '${{ needs.apply-scheduling.outputs.resources_applied }}' || '0',
                 resourcesChanged: '${{ needs.apply-scheduling.outputs.resources_changed }}' || '0',
                 resourcesDestroyed: '${{ needs.apply-scheduling.outputs.resources_destroyed }}' || '0'

--- a/scripts/github-actions/terragrunt-plan-comment.js
+++ b/scripts/github-actions/terragrunt-plan-comment.js
@@ -393,7 +393,7 @@ function createTerragruntPlanComment(inputs) {
       commentBody += `#### 🎨 Format Check Errors\n`;
       commentBody += `Code formatting issues were detected.\n\n`;
       commentBody += `<details><summary>📋 View Format Error Log (Click to expand)</summary>\n\n`;
-      commentBody += `\`\`\`\n${formatTerraformOutput(formatErrorLog).slice(0, 2000)}\`\`\`\n\n`;
+      commentBody += `\`\`\`\n${formatTerraformOutput(formatErrorLog).slice(0, 2000)}\n\`\`\`\n\n`;
       commentBody += `</details>\n\n`;
     }
     
@@ -401,7 +401,7 @@ function createTerragruntPlanComment(inputs) {
       commentBody += `#### ✅ Validation Errors\n`;
       commentBody += `Configuration validation failed.\n\n`;
       commentBody += `<details><summary>📋 View Validation Error Log (Click to expand)</summary>\n\n`;
-      commentBody += `\`\`\`\n${formatTerraformOutput(validateErrorLog).slice(0, 2000)}\`\`\`\n\n`;
+      commentBody += `\`\`\`\n${formatTerraformOutput(validateErrorLog).slice(0, 2000)}\n\`\`\`\n\n`;
       commentBody += `</details>\n\n`;
     }
     
@@ -409,7 +409,7 @@ function createTerragruntPlanComment(inputs) {
       commentBody += `#### 🚀 Initialization Errors\n`;
       commentBody += `Terragrunt initialization failed. Unable to initialize the working directory.\n\n`;
       commentBody += `<details><summary>📋 View Init Error Log (Click to expand)</summary>\n\n`;
-      commentBody += `\`\`\`\n${formatTerraformOutput(initErrorLog).slice(0, 3000)}\`\`\`\n\n`;
+      commentBody += `\`\`\`\n${formatTerraformOutput(initErrorLog).slice(0, 3000)}\n\`\`\`\n\n`;
       commentBody += `</details>\n\n`;
     }
     
@@ -437,7 +437,7 @@ function createTerragruntPlanComment(inputs) {
       }
       
       commentBody += `<details><summary>📋 View Plan Error Log (Click to expand)</summary>\n\n`;
-      commentBody += `\`\`\`\n${formatTerraformOutput(planContentForCheck || planErrorLog).slice(0, 5000)}${(planContentForCheck || planErrorLog).length > 5000 ? '\n... (truncated)' : ''}\`\`\`\n\n`;
+      commentBody += `\`\`\`\n${formatTerraformOutput(planContentForCheck || planErrorLog).slice(0, 5000)}${(planContentForCheck || planErrorLog).length > 5000 ? '\n... (truncated)' : ''}\n\`\`\`\n\n`;
       commentBody += `</details>\n\n`;
     }
     
@@ -555,7 +555,7 @@ function createTerragruntPlanComment(inputs) {
       commentBody += `### 🚨 Plan Execution Error\n\n`;
       commentBody += `Plan execution failed with no output generated.\n\n`;
       commentBody += `<details><summary>📋 View Plan Error Log (Click to expand)</summary>\n\n`;
-      commentBody += `\`\`\`\n${formatTerraformOutput(planErrorLog).slice(0, 5000)}${planErrorLog.length > 5000 ? '\n... (truncated)' : ''}\`\`\`\n\n`;
+      commentBody += `\`\`\`\n${formatTerraformOutput(planErrorLog).slice(0, 5000)}${planErrorLog.length > 5000 ? '\n... (truncated)' : ''}\n\`\`\`\n\n`;
       commentBody += `</details>\n\n`;
       
       commentBody += `### 🔧 Troubleshooting\n`;
@@ -643,7 +643,7 @@ function createTerragruntPlanComment(inputs) {
     } else {
       commentBody += formattedPlanOutput;
     }
-    commentBody += `\`\`\`\n\n`;
+    commentBody += `\n\`\`\`\n\n`;
     commentBody += `</details>\n\n`;
     
   } catch (error) {
@@ -679,7 +679,7 @@ function createTerragruntPlanComment(inputs) {
       if (planErrorLog && planErrorLog.trim() !== '') {
         commentBody += `### 🚨 Plan Error Details\n\n`;
         commentBody += `<details><summary>📋 View Plan Error Log (Click to expand)</summary>\n\n`;
-        commentBody += `\`\`\`\n${formatTerraformOutput(planErrorLog).slice(0, 3000)}\`\`\`\n\n`;
+        commentBody += `\`\`\`\n${formatTerraformOutput(planErrorLog).slice(0, 3000)}\n\`\`\`\n\n`;
         commentBody += `</details>\n\n`;
         
         // Add CI/CD links section for fallback errors


### PR DESCRIPTION
## Problem Fixed

The apply-scheduling job was consistently being skipped despite should_run_scheduling=true due to GitHub Actions limitation where job-level if conditions make the needs context unavailable to dependent jobs.

## Solution

Comprehensive restructuring of apply-keeping job architecture:

### Key Changes
- **Removed job-level if condition** from apply-keeping - now always executes
- **Added internal condition checking** with should-run step  
- **Added determine-status step** to provide accurate apply_status output
- **Updated apply-scheduling condition** to use needs.apply-keeping.outputs.apply_status instead of needs.apply-keeping.result

### Before (Problematic)
apply-keeping had job-level if condition that caused needs context unavailability

### After (Fixed)  
apply-keeping always runs with internal condition checking, ensuring needs context is available

## Testing

This fix addresses the root cause of apply-scheduling job skipping. The restructured architecture ensures:
- needs.apply-keeping context is always available
- apply-scheduling executes when should_run_scheduling=true 
- Proper job dependency management
- Accurate status reporting

## Related Issues

Resolves the persistent apply-scheduling job execution issue experienced in previous test PRs.