### PR TITLE
Fix PR comment handler for apply workflow results

### DIFF
--- a/scripts/github-actions/comment-handler.js
+++ b/scripts/github-actions/comment-handler.js
@@ -89,10 +89,18 @@ async function main(github, context, inputs) {
           applyFilePath: inputs.applyFilePath,
           initErrorLogPath: inputs.initErrorLogPath,
           applyErrorLogPath: inputs.applyErrorLogPath,
-          artifactBasePath: inputs.artifactBasePath
+          artifactBasePath: inputs.artifactBasePath,
+          resourcesApplied: inputs.resourcesApplied,
+          resourcesChanged: inputs.resourcesChanged,
+          resourcesDestroyed: inputs.resourcesDestroyed
         };
         commentBody = createTerragruntApplyComment(applyInputs);
-        await updateTerragruntApplyComment(github, context, commentBody, inputs.environment);
+        
+        // Use prNumber from inputs if provided (from apply workflow)
+        const issueNumber = inputs.prNumber || context.issue.number;
+        console.log(`Using issue number: ${issueNumber} (from ${inputs.prNumber ? 'inputs.prNumber' : 'context.issue.number'})`);
+        
+        await updateTerragruntApplyComment(github, { ...context, issue: { number: issueNumber } }, commentBody, inputs.environment);
         break;
         
       default:


### PR DESCRIPTION
## 概要
apply workflowでのPRコメント投稿が404エラーで失敗していた問題を修正します。

## 問題
- apply workflowからのPRコメント投稿時に、GitHub API URLが正しく形成されず404エラーが発生
- comment-handler.jsがapply workflow contextでPR番号を正しく取得できていなかった

## 修正内容
### scripts/github-actions/comment-handler.js
- terragrunt-apply caseで`inputs.prNumber`を優先的に使用するよう修正
- apply workflowから渡されるPR番号を正しく処理するロジックを追加

### scripts/github-actions/terragrunt-apply-comment.js  
- リソース数をworkflow outputから直接受け取るよう引数を追加
- artifactパースとworkflow output両方に対応

## テスト
- ローカルでの修正確認済み
- apply workflowでのPRコメント投稿フローが正常に動作することを期待

## 関連
- PR #353での適用ジョブ条件修正に続く、PRコメント機能の完全修正