### PR TITLE
Fix context.repo undefined error in apply comment handler

### DIFF
--- a/scripts/github-actions/comment-handler.js
+++ b/scripts/github-actions/comment-handler.js
@@ -99,8 +99,9 @@ async function main(github, context, inputs) {
         // Use prNumber from inputs if provided (from apply workflow)
         const issueNumber = inputs.prNumber || context.issue.number;
         console.log(`Using issue number: ${issueNumber} (from ${inputs.prNumber ? 'inputs.prNumber' : 'context.issue.number'})`);
+        console.log(`Context validation - repo: ${context.repo ? `${context.repo.owner}/${context.repo.repo}` : 'undefined'}`);
         
-        await updateTerragruntApplyComment(github, { ...context, issue: { number: issueNumber } }, commentBody, inputs.environment);
+        await updateTerragruntApplyComment(github, context, commentBody, inputs.environment, issueNumber);
         break;
         
       default:


### PR DESCRIPTION
## 概要
apply workflowでPRコメント投稿時に発生していた `context.repo undefined` エラーを修正します。

## 問題
PR #354マージ後に以下のエラーが発生していました：


## 原因
`comment-handler.js`で`context`オブジェクトを以下のように変更していたため、`context.repo`情報が失われていました：


## 修正内容

### scripts/github-actions/terragrunt-apply-comment.js
- `updateTerragruntApplyComment`関数に`issueNumber`パラメータを追加
- `context.repo`の存在確認とバリデーションを追加
- 詳細なデバッグログを追加してトラブルシューティングを改善

### scripts/github-actions/comment-handler.js  
- `context`オブジェクトを変更せずに、`issueNumber`を直接渡すように修正
- デバッグ用のコンテキスト情報ログを追加

## テスト
- ローカルでの修正確認済み
- `context.repo.owner`へのアクセスエラーが解決されることを確認

## 関連
- PR #354のフォローアップ修正
- apply workflowでのPRコメント投稿機能の完全修正