### PR TITLE
Makefile: provider.tf自動削除対応（keeping/scheduling両対応）とscheduling/main.tfの修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+init-reconfigure: ## Reinitialize Terraform backend for both environments (force reconfigure)
+	cd terraform/keeping && terraform init -reconfigure
+	cd terraform/scheduling && terraform init -reconfigure
 .PHONY: help install-tools validate fmt plan apply destroy clean
 
 # Default target
@@ -130,52 +133,69 @@ upgrade-modules: ## Upgrade all Terraform modules to latest versions
 # Terragrunt commands
 tg-validate: ## Validate Terragrunt configurations
 	@echo "🔍 Validating Terragrunt configurations..."
+	rm -f terraform/keeping/provider.tf
+	rm -f terraform/scheduling/provider.tf
 	cd terragrunt/environments/keeping && terragrunt validate
 	cd terragrunt/environments/scheduling && terragrunt validate
 	@echo "✅ All Terragrunt configurations are valid"
 
 tg-init: ## Initialize Terragrunt for both environments
 	@echo "🔄 Initializing Terragrunt configurations..."
+	rm -rf .terragrunt-cache
+	rm -rf terragrunt/environments/keeping/.terragrunt-cache
+	rm -rf terragrunt/environments/scheduling/.terragrunt-cache
+	rm -f terraform/keeping/provider.tf
+	rm -f terraform/scheduling/provider.tf
 	cd terragrunt/environments/keeping && terragrunt init
 	cd terragrunt/environments/scheduling && terragrunt init
 	@echo "✅ Terragrunt initialization complete"
 
 tg-plan-keeping: ## Show Terragrunt plan for keeping resources
+	rm -f terraform/keeping/provider.tf
 	cd terragrunt/environments/keeping && terragrunt plan
 
 tg-plan-scheduling: ## Show Terragrunt plan for scheduling resources
+	rm -f terraform/scheduling/provider.tf
 	cd terragrunt/environments/scheduling && terragrunt plan
 
 tg-plan-all: ## Show Terragrunt plans for both environments
 	@echo "📋 Planning keeping resources..."
+	rm -f terraform/keeping/provider.tf
 	cd terragrunt/environments/keeping && terragrunt plan
 	@echo "📋 Planning scheduling resources..."
+	rm -f terraform/scheduling/provider.tf
 	cd terragrunt/environments/scheduling && terragrunt plan
 
 tg-deploy-all: ## Deploy all resources using Terragrunt (keeping -> scheduling)
 	@echo "🚀 Starting Terragrunt deployment..."
 	@echo "📋 Step 1: Deploying keeping resources..."
+	rm -f terraform/keeping/provider.tf
 	cd terragrunt/environments/keeping && terragrunt apply
 	@echo "✅ Keeping resources deployed successfully"
 	@echo "📋 Step 2: Deploying scheduling resources..."
+	rm -f terraform/scheduling/provider.tf
 	cd terragrunt/environments/scheduling && terragrunt apply
 	@echo "🎉 All resources deployed successfully!"
 
 tg-start-minecraft: ## Start minecraft server using Terragrunt
 	@echo "🎮 Starting Minecraft server with Terragrunt..."
+	rm -f terraform/scheduling/provider.tf
 	cd terragrunt/environments/scheduling && terragrunt apply
 	@echo "✅ Minecraft server started!"
 
 tg-stop-minecraft: ## Stop minecraft server using Terragrunt
 	@echo "🛑 Stopping Minecraft server with Terragrunt..."
+	rm -f terraform/scheduling/provider.tf
 	cd terragrunt/environments/scheduling && terragrunt destroy
 	@echo "✅ Minecraft server stopped!"
 
 tg-destroy-all: ## Destroy all resources using Terragrunt (reverse order)
 	@echo "🗑️  Starting Terragrunt destruction..."
 	@echo "📋 Step 1: Destroying scheduling resources..."
+	rm -f terraform/scheduling/provider.tf
 	cd terragrunt/environments/scheduling && terragrunt destroy
 	@echo "✅ Scheduling resources destroyed"
 	@echo "📋 Step 2: Destroying keeping resources..."
+	rm -f terraform/keeping/provider.tf
 	cd terragrunt/environments/keeping && terragrunt destroy
 	@echo "🎉 All resources destroyed successfully!"

--- a/terraform/keeping/.terraform.lock.hcl
+++ b/terraform/keeping/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.8.0"
-  constraints = ">= 3.29.0, >= 5.30.0, >= 5.32.0, ~> 6.8"
+  constraints = ">= 3.29.0, >= 5.30.0, >= 6.0.0"
   hashes = [
     "h1:AKzP2NxGfL915FP9CDJacRHmDeKB+V96OfpbLaQuPVM=",
+    "h1:HDnB+foDh9HJd81T+ddn2tC0DXonSUwovBdvuKe9dZs=",
     "zh:04781915164a85316d2f659383bb4a2c26ce258efdd63b10ebf5dc741b13d3a4",
     "zh:050eba0f1d40b6a2542206742fbf8697b139e045120e50b59fa090eb1babb46d",
     "zh:0590b7ba32f211142fc1acc1350560ce47faa287aeec697b577c9fe10e0efcab",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
@@ -44,29 +46,11 @@ provider "registry.terraform.io/hashicorp/external" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/http" {
-  version = "3.5.0"
-  hashes = [
-    "h1:KsglDyFg9a9CIlOKxSSl8gDi+SAKfY+uvIZO1+SpeAc=",
-    "zh:047c5b4920751b13425efe0d011b3a23a3be97d02d9c0e3c60985521c9c456b7",
-    "zh:157866f700470207561f6d032d344916b82268ecd0cf8174fb11c0674c8d0736",
-    "zh:1973eb9383b0d83dd4fd5e662f0f16de837d072b64a6b7cd703410d730499476",
-    "zh:212f833a4e6d020840672f6f88273d62a564f44acb0c857b5961cdb3bbc14c90",
-    "zh:2c8034bc039fffaa1d4965ca02a8c6d57301e5fa9fff4773e684b46e3f78e76a",
-    "zh:5df353fc5b2dd31577def9cc1a4ebf0c9a9c2699d223c6b02087a3089c74a1c6",
-    "zh:672083810d4185076c81b16ad13d1224b9e6ea7f4850951d2ab8d30fa6e41f08",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7b4200f18abdbe39904b03537e1a78f21ebafe60f1c861a44387d314fda69da6",
-    "zh:843feacacd86baed820f81a6c9f7bd32cf302db3d7a0f39e87976ebc7a7cc2ee",
-    "zh:a9ea5096ab91aab260b22e4251c05f08dad2ed77e43e5e4fadcdfd87f2c78926",
-    "zh:d02b288922811739059e90184c7f76d45d07d3a77cc48d0b15fd3db14e928623",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.3"
   constraints = ">= 1.0.0"
   hashes = [
+    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
     "h1:Zy6RilIeIWBXksQWXjCLbqr9Om9R8cWX+axQlLebppM=",
     "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
     "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
@@ -85,9 +69,10 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
-  constraints = ">= 2.0.0, ~> 3.2"
+  constraints = ">= 2.0.0"
   hashes = [
     "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
@@ -100,24 +85,5 @@ provider "registry.terraform.io/hashicorp/null" {
     "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
     "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
     "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/tls" {
-  version = "4.1.0"
-  hashes = [
-    "h1:uDtqTpFJOseNUlPDx4TT/lXf6ie3CarsimL7sYCiVH4=",
-    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
-    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
-    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
-    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
-    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
-    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
-    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
-    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
-    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
-    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
   ]
 }

--- a/terraform/keeping/variables.tf
+++ b/terraform/keeping/variables.tf
@@ -15,6 +15,11 @@ variable "owners" {
   type        = string
 }
 
+variable "service" {
+  description = "Service type (keeping or scheduling)"
+  type        = string
+}
+
 variable "aws_account_id" {
   description = "Account ID in which AWS Resoruces to be created"
   type        = string
@@ -63,9 +68,10 @@ variable "common_tags" {
 locals {
   owners      = var.owners
   environment = var.environment
+  service     = var.service
   name        = "${var.owners}-${var.environment}"
   common_tags = {
-    owners      = local.owners
-    environment = local.environment
+    owners  = local.owners
+    service = local.service
   }
 }

--- a/terraform/modules/chatbot/chatbot.tf
+++ b/terraform/modules/chatbot/chatbot.tf
@@ -12,7 +12,5 @@ resource "aws_chatbot_slack_channel_configuration" "chatbot_slack_configuration"
   guardrail_policy_arns = [
     "arn:aws:iam::aws:policy/ReadOnlyAccess"
   ]
-
-  tags = local.common_tags
 }
 

--- a/terraform/modules/chatbot/variables.tf
+++ b/terraform/modules/chatbot/variables.tf
@@ -1,3 +1,10 @@
+variable "owners" {}
+variable "environment" {}
+locals {
+  owners      = var.owners
+  environment = var.environment
+  name        = "${var.owners}-${var.environment}"
+}
 variable "chatbot_slack_id" {
   description = "The ID of the Slack channel. To get the ID, open Slack, right click on the channel name in the left pane, then choose Copy Link. The channel ID is the 9-character string at the end of the URL. For example, ABCBBLZZZ."
   sensitive   = true
@@ -16,15 +23,4 @@ variable "chatbot_notification_role_arn" {
   description = "The ARN of chatbot notification only role"
 }
 
-variable "owners" {}
-variable "environment" {}
 
-locals {
-  owners      = var.owners
-  environment = var.environment
-  name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
-}

--- a/terraform/modules/cloudwatch/variables.tf
+++ b/terraform/modules/cloudwatch/variables.tf
@@ -1,3 +1,10 @@
+variable "owners" {}
+variable "environment" {}
+locals {
+  owners      = var.owners
+  environment = var.environment
+  name        = "${var.owners}-${var.environment}"
+}
 variable "firelens_log_group" {
   type = string
 }
@@ -24,15 +31,3 @@ variable "sns_topic_arn" {
   description = "ARN of the SNS topic to subscribe to."
 }
 
-variable "owners" {}
-variable "environment" {}
-
-locals {
-  owners      = var.owners
-  environment = var.environment
-  name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
-}

--- a/terraform/modules/domain/variables.tf
+++ b/terraform/modules/domain/variables.tf
@@ -1,3 +1,10 @@
+variable "owners" {}
+variable "environment" {}
+locals {
+  owners      = var.owners
+  environment = var.environment
+  name        = "${var.owners}-${var.environment}"
+}
 variable "nlb_dns_name" {
   description = "DNS Name of nlb to register in route53"
   type        = string
@@ -16,15 +23,4 @@ variable "acm_certificate_arn" {
 }
 
 
-variable "owners" {}
-variable "environment" {}
 
-locals {
-  owners      = var.owners
-  environment = var.environment
-  name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
-}

--- a/terraform/modules/ecs/ecs_cluster.tf
+++ b/terraform/modules/ecs/ecs_cluster.tf
@@ -10,5 +10,4 @@ resource "aws_ecs_cluster" "main" {
     name  = "containerInsights"
     value = "enabled"
   }
-  tags = local.common_tags
 }

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -1,3 +1,10 @@
+variable "owners" {}
+variable "environment" {}
+locals {
+  owners      = var.owners
+  environment = var.environment
+  name        = "${var.owners}-${var.environment}"
+}
 ##########################
 # ECS Input Variables    #
 # ECS Cluster Name       #
@@ -115,17 +122,6 @@ variable "seed_value" {
 # Define Local Values in Terraform     #
 ########################################
 
-variable "owners" {}
-variable "environment" {}
 variable "aws_region" {}
 variable "aws_account_id" {}
 
-locals {
-  owners      = var.owners
-  environment = var.environment
-  name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
-}

--- a/terraform/modules/efs/efs.tf
+++ b/terraform/modules/efs/efs.tf
@@ -9,7 +9,6 @@ resource "aws_efs_file_system" "main" {
     transition_to_primary_storage_class = "AFTER_1_ACCESS"
   }
 
-  tags = local.common_tags
 }
 
 resource "aws_efs_backup_policy" "main" {

--- a/terraform/modules/efs/variables.tf
+++ b/terraform/modules/efs/variables.tf
@@ -1,3 +1,10 @@
+variable "owners" {}
+variable "environment" {}
+locals {
+  owners      = var.owners
+  environment = var.environment
+  name        = "${var.owners}-${var.environment}"
+}
 variable "vpc_id" {
   type = string
 }
@@ -15,15 +22,4 @@ variable "security_group_id" {
   type = string
 }
 
-variable "owners" {}
-variable "environment" {}
 
-locals {
-  owners      = var.owners
-  environment = var.environment
-  name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
-}

--- a/terraform/modules/github/main.tf
+++ b/terraform/modules/github/main.tf
@@ -7,7 +7,6 @@ resource "aws_iam_role" "github_actions" {
       github_repo = var.github_repo
     }
   )
-  tags = local.common_tags
 }
 
 resource "aws_iam_policy" "github_actions" {

--- a/terraform/modules/github/variables.tf
+++ b/terraform/modules/github/variables.tf
@@ -1,15 +1,11 @@
-variable "account_id" {}
-variable "github_org" {}
-variable "github_repo" {}
 variable "owners" {}
 variable "environment" {}
-
 locals {
   owners      = var.owners
   environment = var.environment
   name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
 }
+variable "account_id" {}
+variable "github_org" {}
+variable "github_repo" {}
+

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -1,18 +1,14 @@
-########################################
-# Define Local Values in Terraform     #
-########################################
-
 variable "owners" {}
 variable "environment" {}
-variable "aws_region" {}
-variable "aws_account_id" {}
-
 locals {
   owners      = var.owners
   environment = var.environment
   name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
 }
+########################################
+# Define Local Values in Terraform     #
+########################################
+
+variable "aws_region" {}
+variable "aws_account_id" {}
+

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -1,3 +1,10 @@
+variable "owners" {}
+variable "environment" {}
+locals {
+  owners      = var.owners
+  environment = var.environment
+  name        = "${var.owners}-${var.environment}"
+}
 variable "log_group_name" {
   type        = string
   description = "The name of cloudwatch log group to apply subscription filter via lambda"
@@ -33,15 +40,4 @@ variable "sns_kms_key_arn" {
   description = "The ARN of the KMS key to use for encryption"
 }
 
-variable "owners" {}
-variable "environment" {}
 
-locals {
-  owners      = var.owners
-  environment = var.environment
-  name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
-}

--- a/terraform/modules/nlb/nlb.tf
+++ b/terraform/modules/nlb/nlb.tf
@@ -71,7 +71,6 @@ module "nlb" {
         timeout             = 5
         protocol            = "TCP"
       }
-      tags = local.common_tags
     }
     ex-target-two = {
       protocol                          = "TCP"
@@ -80,12 +79,10 @@ module "nlb" {
       deregistration_delay              = 10
       create_attachment                 = false
       load_balancing_cross_zone_enabled = false
-      tags                              = local.common_tags
     }
   }
   enable_deletion_protection = false
 
-  tags = local.common_tags
 }
 
 resource "null_resource" "send_slack_notification" {

--- a/terraform/modules/nlb/variables.tf
+++ b/terraform/modules/nlb/variables.tf
@@ -1,3 +1,10 @@
+variable "owners" {}
+variable "environment" {}
+locals {
+  owners      = var.owners
+  environment = var.environment
+  name        = "${var.owners}-${var.environment}"
+}
 ############################
 # VPC Input Variables      #
 ############################
@@ -35,15 +42,4 @@ variable "vpc_cidr_block" {
 # Terraform AWS Application Load Balancer Variables #
 # Place holder file for AWS ALB Variables           #
 #####################################################
-variable "owners" {}
-variable "environment" {}
 
-locals {
-  owners      = var.owners
-  environment = var.environment
-  name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
-}

--- a/terraform/modules/slash_command/variables.tf
+++ b/terraform/modules/slash_command/variables.tf
@@ -1,3 +1,10 @@
+variable "owners" {}
+variable "environment" {}
+locals {
+  owners      = var.owners
+  environment = var.environment
+  name        = "${var.owners}-${var.environment}"
+}
 variable "github_token" {
   type        = string
   description = "Github token"
@@ -24,15 +31,4 @@ variable "aws_account_id" {
   type        = string
 }
 
-variable "owners" {}
-variable "environment" {}
 
-locals {
-  owners      = var.owners
-  environment = var.environment
-  name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
-}

--- a/terraform/modules/sns/sns.tf
+++ b/terraform/modules/sns/sns.tf
@@ -46,7 +46,6 @@ resource "aws_sns_topic" "main" {
 }
 POLICY
 
-  tags = local.common_tags
 }
 
 resource "aws_sns_topic_subscription" "main" {

--- a/terraform/modules/sns/variables.tf
+++ b/terraform/modules/sns/variables.tf
@@ -1,13 +1,9 @@
 variable "owners" {}
 variable "environment" {}
-variable "aws_account_id" {}
-
 locals {
   owners      = var.owners
   environment = var.environment
   name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
 }
+variable "aws_account_id" {}
+

--- a/terraform/modules/vpc/security_group.tf
+++ b/terraform/modules/vpc/security_group.tf
@@ -9,7 +9,6 @@ module "fargate_sg" {
   vpc_id      = module.vpc.vpc_id
 
   egress_rules = ["all-all"]
-  tags         = local.common_tags
   # Open for self (rule or from_port+to_port+protocol+description)
   ingress_with_self = [
     {

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -38,8 +38,4 @@ locals {
   owners      = var.owners
   environment = var.environment
   name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
 }

--- a/terraform/modules/vpc/vpc.tf
+++ b/terraform/modules/vpc/vpc.tf
@@ -10,8 +10,6 @@ module "vpc" {
   public_subnets       = var.vpc_public_subnets
   enable_dns_hostnames = true
 
-  tags     = local.common_tags
-  vpc_tags = local.common_tags
 
   # Additional Tags to Subnets
   public_subnet_tags = {

--- a/terraform/scheduling/.terraform.lock.hcl
+++ b/terraform/scheduling/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.8.0"
-  constraints = ">= 5.32.0, >= 5.59.0, ~> 6.8"
+  constraints = ">= 5.59.0, >= 6.0.0"
   hashes = [
     "h1:AKzP2NxGfL915FP9CDJacRHmDeKB+V96OfpbLaQuPVM=",
+    "h1:HDnB+foDh9HJd81T+ddn2tC0DXonSUwovBdvuKe9dZs=",
     "zh:04781915164a85316d2f659383bb4a2c26ce258efdd63b10ebf5dc741b13d3a4",
     "zh:050eba0f1d40b6a2542206742fbf8697b139e045120e50b59fa090eb1babb46d",
     "zh:0590b7ba32f211142fc1acc1350560ce47faa287aeec697b577c9fe10e0efcab",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.3"
   constraints = ">= 1.0.0"
   hashes = [
+    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
     "h1:Zy6RilIeIWBXksQWXjCLbqr9Om9R8cWX+axQlLebppM=",
     "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
     "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
@@ -66,9 +69,10 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
-  constraints = ">= 2.0.0, ~> 3.2"
+  constraints = ">= 2.0.0"
   hashes = [
     "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",

--- a/terraform/scheduling/main.tf
+++ b/terraform/scheduling/main.tf
@@ -8,16 +8,16 @@ data "aws_vpc" "myvpc" {
 data "aws_security_group" "fargate_sg" {
   filter {
     name   = "tag:Name"
-    values = ["minecraft-keeping-fargate-sg"]
+    values = ["minecraft-test-fargate-sg"]
   }
 }
 
 data "aws_iam_role" "task_role" {
-  name = "ecs_tasks-minecraft-keeping-role"
+  name = "ecs_tasks-minecraft-test-role"
 }
 
 data "aws_iam_role" "task_execution_role" {
-  name = "minecraft-keeping-ecs_tasks_execution-role"
+  name = "minecraft-test-ecs_tasks_execution-role"
 }
 
 # data "aws_efs_file_system" "my_efs" {
@@ -25,7 +25,7 @@ data "aws_iam_role" "task_execution_role" {
 # }
 
 data "aws_sns_topic" "my_sns" {
-  name = "minecraft-keeping-sns-topic"
+  name = "minecraft-test-sns-topic"
 }
 
 data "aws_kms_key" "my_kms" {

--- a/terraform/scheduling/variables.tf
+++ b/terraform/scheduling/variables.tf
@@ -1,3 +1,7 @@
+variable "service" {
+  description = "Service type (keeping or scheduling)"
+  type        = string
+}
 # Input Variables
 # AWS Region
 variable "aws_region" {
@@ -77,11 +81,8 @@ variable "seed_value" {
 locals {
   owners      = var.owners
   environment = var.environment
+  service     = var.service
   name        = "${var.owners}-${var.environment}"
-  common_tags = {
-    owners      = local.owners
-    environment = local.environment
-  }
 
   merged_decoded_yaml = merge([for f in var.env_files : yamldecode(file(f))]...)
   updated_list        = { for k, v in local.merged_decoded_yaml : k => v if k != "FILTERING_STRINGS" }

--- a/terragrunt/environments/keeping/.terraform.lock.hcl
+++ b/terragrunt/environments/keeping/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.8.0"
-  constraints = ">= 3.29.0, >= 5.30.0, >= 5.32.0, ~> 6.8"
+  constraints = ">= 3.29.0, >= 5.30.0, >= 6.0.0, ~> 6.8"
   hashes = [
     "h1:AKzP2NxGfL915FP9CDJacRHmDeKB+V96OfpbLaQuPVM=",
+    "h1:HDnB+foDh9HJd81T+ddn2tC0DXonSUwovBdvuKe9dZs=",
     "zh:04781915164a85316d2f659383bb4a2c26ce258efdd63b10ebf5dc741b13d3a4",
     "zh:050eba0f1d40b6a2542206742fbf8697b139e045120e50b59fa090eb1babb46d",
     "zh:0590b7ba32f211142fc1acc1350560ce47faa287aeec697b577c9fe10e0efcab",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
@@ -44,29 +46,11 @@ provider "registry.terraform.io/hashicorp/external" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/http" {
-  version = "3.5.0"
-  hashes = [
-    "h1:KsglDyFg9a9CIlOKxSSl8gDi+SAKfY+uvIZO1+SpeAc=",
-    "zh:047c5b4920751b13425efe0d011b3a23a3be97d02d9c0e3c60985521c9c456b7",
-    "zh:157866f700470207561f6d032d344916b82268ecd0cf8174fb11c0674c8d0736",
-    "zh:1973eb9383b0d83dd4fd5e662f0f16de837d072b64a6b7cd703410d730499476",
-    "zh:212f833a4e6d020840672f6f88273d62a564f44acb0c857b5961cdb3bbc14c90",
-    "zh:2c8034bc039fffaa1d4965ca02a8c6d57301e5fa9fff4773e684b46e3f78e76a",
-    "zh:5df353fc5b2dd31577def9cc1a4ebf0c9a9c2699d223c6b02087a3089c74a1c6",
-    "zh:672083810d4185076c81b16ad13d1224b9e6ea7f4850951d2ab8d30fa6e41f08",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7b4200f18abdbe39904b03537e1a78f21ebafe60f1c861a44387d314fda69da6",
-    "zh:843feacacd86baed820f81a6c9f7bd32cf302db3d7a0f39e87976ebc7a7cc2ee",
-    "zh:a9ea5096ab91aab260b22e4251c05f08dad2ed77e43e5e4fadcdfd87f2c78926",
-    "zh:d02b288922811739059e90184c7f76d45d07d3a77cc48d0b15fd3db14e928623",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.3"
   constraints = ">= 1.0.0"
   hashes = [
+    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
     "h1:Zy6RilIeIWBXksQWXjCLbqr9Om9R8cWX+axQlLebppM=",
     "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
     "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
@@ -88,6 +72,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = ">= 2.0.0, ~> 3.2"
   hashes = [
     "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
@@ -100,24 +85,5 @@ provider "registry.terraform.io/hashicorp/null" {
     "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
     "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
     "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/tls" {
-  version = "4.1.0"
-  hashes = [
-    "h1:uDtqTpFJOseNUlPDx4TT/lXf6ie3CarsimL7sYCiVH4=",
-    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
-    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
-    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
-    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
-    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
-    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
-    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
-    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
-    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
-    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
   ]
 }

--- a/terragrunt/environments/keeping/terragrunt.hcl
+++ b/terragrunt/environments/keeping/terragrunt.hcl
@@ -25,8 +25,8 @@ inputs = {
   aws_region     = local.aws_region
   aws_account_id = get_env("AWS_ACCOUNT_ID", "123456789012") # Set your account ID
 
-  # Environment-specific variables
-  environment = "keeping"
+  # Service tag for keeping environment
+  service     = "keeping"
   owners      = "minecraft"
 
   # Common tags

--- a/terragrunt/environments/scheduling/.terraform.lock.hcl
+++ b/terragrunt/environments/scheduling/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.8.0"
-  constraints = ">= 5.32.0, >= 5.59.0, ~> 6.8"
+  constraints = ">= 5.59.0, >= 6.0.0, ~> 6.8"
   hashes = [
     "h1:AKzP2NxGfL915FP9CDJacRHmDeKB+V96OfpbLaQuPVM=",
+    "h1:HDnB+foDh9HJd81T+ddn2tC0DXonSUwovBdvuKe9dZs=",
     "zh:04781915164a85316d2f659383bb4a2c26ce258efdd63b10ebf5dc741b13d3a4",
     "zh:050eba0f1d40b6a2542206742fbf8697b139e045120e50b59fa090eb1babb46d",
     "zh:0590b7ba32f211142fc1acc1350560ce47faa287aeec697b577c9fe10e0efcab",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.3"
   constraints = ">= 1.0.0"
   hashes = [
+    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
     "h1:Zy6RilIeIWBXksQWXjCLbqr9Om9R8cWX+axQlLebppM=",
     "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
     "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
@@ -69,6 +72,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = ">= 2.0.0, ~> 3.2"
   hashes = [
     "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",

--- a/terragrunt/environments/scheduling/terragrunt.hcl
+++ b/terragrunt/environments/scheduling/terragrunt.hcl
@@ -30,8 +30,8 @@ inputs = {
   aws_region     = local.aws_region
   aws_account_id = get_env("AWS_ACCOUNT_ID", "123456789012") # Set your account ID
 
-  # Environment-specific variables
-  environment = "scheduling"
+  # Service tag for scheduling environment
+  service     = "scheduling"
   owners      = "minecraft"
 
   # Common tags


### PR DESCRIPTION
概要
MakefileのTerragrunt関連コマンド（init, validate, plan, apply, destroy等）で、terraform/keeping/provider.tf および terraform/scheduling/provider.tf を自動削除するよう対応しました。これにより、provider.tfの競合や手動削除の手間が不要となります。

主な変更点
Makefileの全tg-*コマンドで、keeping/scheduling両方のprovider.tfを事前に削除
terraform/scheduling/main.tfの修正
各種モジュール・環境の変数定義、タグ、ロックファイル等の整理・重複排除
terragrunt/environments/keeping, schedulingのterragrunt.hcl修正
背景・目的
Terragrunt実行時にprovider.tfの競合が発生しやすく、毎回手動で削除する運用負荷が高かったため、Makefileで自動化しました。また、タグや変数定義の一元化・重複排除も併せて実施しています。

動作確認
make tg-init, make tg-validate, make tg-plan-all, make tg-deploy-all など全てのTerragruntコマンドでprovider.tfが自動削除され、エラーなく実行できることを確認済み