### PR TITLE
provider.tf生成内容にdefault_tags追加 (Owner, Environment, Service)

### DIFF
--- a/terragrunt/terragrunt.hcl
+++ b/terragrunt/terragrunt.hcl
@@ -40,6 +40,13 @@ terraform {
 # Provider Block
 provider "aws" {
   region = var.aws_region
+  default_tags {
+    tags = {
+      Owner      = var.owners
+      Environment = var.environment
+      Service     = var.service
+    }
+  }
 }
 EOF
 }
@@ -53,12 +60,6 @@ locals {
     alb    = "9.10.0"
   }
 
-  # Common tags
-  common_tags = {
-    Project     = "minecraft-server"
-    ManagedBy   = "terragrunt"
-    Environment = basename(dirname(get_terragrunt_dir()))
-  }
 
   # AWS configuration
   aws_region = "ap-northeast-1"


### PR DESCRIPTION
概要
AWS Providerの default_tags を provider.tf 生成内容に追加し、全リソースに Owner・Environment・Service タグが自動付与されるようにしました。

変更内容
[terragrunt.hcl](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) の generate \"provider\" ブロックで生成する provider.tf に default_tags を追加
タグ内容は Owner（var.owners）、Environment（var.environment）、Service（var.service）
背景・目的
これまで各リソースごとにタグ付けしていましたが、default_tags を使うことでタグ管理を一元化し、運用・管理の手間を削減します。

動作確認
Terragrunt経由でprovider.tfが生成され、AWSリソースに指定タグが自動付与されることを確認済み